### PR TITLE
Use path seperators to provide support for Windows environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const ruleChildren = (loader) => loader.use || loader.oneOf || Array.isArray(loader.loader) && loader.loader || []
 
 const findIndexAndRules = (rulesSource, ruleMatcher) => {
@@ -7,7 +8,7 @@ const findIndexAndRules = (rulesSource, ruleMatcher) => {
     return result
 }
 
-const createLoaderMatcher = (loader) => (rule) => rule.loader && rule.loader.indexOf(`/${loader}/`) !== -1
+const createLoaderMatcher = (loader) => (rule) => rule.loader && rule.loader.indexOf(`${path.sep}${loader}${path.sep}`) !== -1
 const fileLoaderMatcher = createLoaderMatcher('file-loader')
 
 const addBeforeRule = (rulesSource, ruleMatcher, value) => {

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,5 @@
 const subject = require('./index')
+const path = require("path")
 
 describe('SVG React Loader rewire', () => {
 
@@ -9,40 +10,40 @@ describe('SVG React Loader rewire', () => {
                     test: /\.(js|jsx|mjs)$/,
                     enforce: 'pre',
                     use: [
-                        {options: {}, loader: '/path/to/eslint-loader/index.js'}
+                        {options: {}, loader: path.resolve(__dirname, '/path/to/eslint-loader/index.js')}
                     ],
-                    include: '/path/to/src'
+                    include: path.resolve(__dirname, '/path/to/src')
                 },
                 {
                     oneOf: [
                         {
                             test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
-                            loader: '/path/to/url-loader/index.js',
+                            loader: path.resolve(__dirname, '/path/to/url-loader/index.js'),
                             options: {},
                         },
                         {
                             test: /\.(js|jsx|mjs)$/,
-                            include: '/path/to/src',
-                            loader: '/path/to/babel-loader/lib/index.js',
+                            include: path.resolve(__dirname, '/path/to/src'),
+                            loader: path.resolve(__dirname, '/path/to/babel-loader/lib/index.js'),
                             options: {},
                         },
                         {
                             test: /\.css$/,
                             use: [
-                                '/path/to/style-loader/index.js',
+                                path.resolve(__dirname, '/path/to/style-loader/index.js'),
                                 {
-                                    loader: '/path/to/css-loader/index.js',
+                                    loader: path.resolve(__dirname, '/path/to/css-loader/index.js'),
                                     options: {},
                                 },
                                 {
-                                    loader: '/path/to/postcss-loader/lib/index.js',
+                                    loader: path.resolve(__dirname, '/path/to/postcss-loader/lib/index.js'),
                                     options: {},
                                 },
                             ],
                         },
                         {
                             exclude: [/\.js$/, /\.html$/, /\.json$/],
-                            loader: '/path/to/file-loader/dist/cjs.js',
+                            loader: path.resolve(__dirname, '/path/to/file-loader/dist/cjs.js'),
                             options: {name: 'static/media/[name].[hash:8].[ext]'},
                         },
                     ]
@@ -57,47 +58,47 @@ describe('SVG React Loader rewire', () => {
                     test: /\.(js|jsx|mjs)$/,
                     enforce: 'pre',
                     use: [
-                        {options: {}, loader: '/path/to/eslint-loader/index.js'}
+                        {options: {}, loader: path.resolve(__dirname, '/path/to/eslint-loader/index.js')}
                     ],
-                    include: '/path/to/src'
+                    include: path.resolve(__dirname, '/path/to/src')
                 },
                 {
                     oneOf: [
                         {
                             test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
-                            loader: '/path/to/url-loader/index.js',
+                            loader: path.resolve(__dirname, '/path/to/url-loader/index.js'),
                             options: {},
                         },
                         {
                             test: /\.(js|jsx|mjs)$/,
-                            include: '/path/to/src',
-                            loader: '/path/to/babel-loader/lib/index.js',
+                            include: path.resolve(__dirname, '/path/to/src'),
+                            loader: path.resolve(__dirname, '/path/to/babel-loader/lib/index.js'),
                             options: {},
                         },
                         {
                             test: /\.css$/,
                             loader: [
                                 {
-                                    loader: '/path/to/extract-text-webpack-plugin/dist/loader.js',
+                                    loader: path.resolve(__dirname, '/path/to/extract-text-webpack-plugin/dist/loader.js'),
                                     options: {}
                                 },
                                 {
-                                    loader: '/path/to/style-loader/index.js',
+                                    loader: path.resolve(__dirname, '/path/to/style-loader/index.js'),
                                     options: {}
                                 },
                                 {
-                                    loader: '/path/to/css-loader/index.js',
+                                    loader: path.resolve(__dirname, '/path/to/css-loader/index.js'),
                                     options: {}
                                 },
                                 {
-                                    loader: '/path/to/postcss-loader/lib/index.js',
+                                    loader: path.resolve(__dirname, '/path/to/postcss-loader/lib/index.js'),
                                     options: {}
                                 }
                             ]
                         },
                         {
                             exclude: [/\.js$/, /\.html$/, /\.json$/],
-                            loader: '/path/to/file-loader/dist/cjs.js',
+                            loader: path.resolve(__dirname, '/path/to/file-loader/dist/cjs.js'),
                             options: {name: 'static/media/[name].[hash:8].[ext]'},
                         },
                     ]
@@ -116,11 +117,11 @@ describe('SVG React Loader rewire', () => {
         })
 
         it('should set loader on the configuration', () => {
-            expect(svgLoader.loader).toContain('/svg-react-loader/')
+            expect(svgLoader.loader).toContain(`${path.sep}svg-react-loader${path.sep}`)
         })
 
         it('should insert the SVG loader before the file loader', () => {
-            expect(fileLoader.loader).toContain('/file-loader/')
+            expect(fileLoader.loader).toContain(`${path.sep}file-loader${path.sep}`)
         })
     })
 
@@ -135,11 +136,11 @@ describe('SVG React Loader rewire', () => {
         })
 
         it('should set loader on the configuration', () => {
-            expect(svgLoader.loader).toContain('/svg-react-loader/')
+            expect(svgLoader.loader).toContain(`${path.sep}svg-react-loader${path.sep}`)
         })
 
         it('should insert the SVG loader before the file loader', () => {
-            expect(fileLoader.loader).toContain('/file-loader/')
+            expect(fileLoader.loader).toContain(`${path.sep}file-loader${path.sep}`)
         })
     })
 })


### PR DESCRIPTION
Proposed solution to the issue I have raised [here].(https://github.com/codebandits/react-app-rewire-svg-react-loader/issues/1)