### PR TITLE
Exclude node modules to avoid conflicts with dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const addBeforeRule = (rulesSource, ruleMatcher, value) => {
 module.exports = function (config, env) {
     const svgReactLoader = {
         test: /\.svg$/,
+        exclude: [/[/\\\\]node_modules[/\\\\]/],
         loader: require.resolve('svg-react-loader')
     }
 


### PR DESCRIPTION
Hi, I'm using this rewire in a CRA project while waiting for react-scripts 2.0, which should support importing SVG as components out-of-the-box.

I've run into an issue using it with React Semantic UI's Icons, I suppose because they are also bundled by webpack as the svg rule doesn't exclude `node_modules` (like the `next` branch of CRA now does, in a quite different way though, using svgr and named imports: https://github.com/facebook/create-react-app/blob/next/packages/react-scripts/config/webpack.config.dev.js#L209).

In the meantime I've forked this repo and created a PR, if you think this would benefit other people using this package please feel free to merge! :)

Cheers!