### PR TITLE
Added Webpack & SVG React Loader Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ export default () => (
     <div>look, it's a triangle: <Triangle/></div>
 )
 ```
+
+### Webpack & SVG React Loader Options
+
+If you need to add extra webpack or SVG react loader options, you can pass them as additional arguments in your `config-overrides.js` file:
+
+```javascript
+
+config = rewireSvgReactLoader(config, env, {
+    // webpack config options
+    include: []
+},
+{
+    // SVG react loader options
+    classIdPrefix: '[name]-[hash:8]__',
+});
+```
+
+If you want to include SVG react loader options but not webpack options, be sure to pass in an empty dictionary as the 3rd argument. You can get more information on those options in the [SVG react loader documentation](https://github.com/jhamlet/svg-react-loader#query-params).

--- a/index.js
+++ b/index.js
@@ -16,10 +16,22 @@ const addBeforeRule = (rulesSource, ruleMatcher, value) => {
     rules.splice(index, 0, value)
 }
 
-module.exports = function (config, env) {
-    const svgReactLoader = {
+module.exports = function (config, env, webpackOptions = {}, svgReactLoaderOptions = {}) {
+    const defaults = {
         test: /\.svg$/,
-        loader: require.resolve('svg-react-loader')
+        loader: require.resolve('svg-react-loader'),
+    }
+
+    // merge any extra webpack options into the default config
+    var svgReactLoader = Object.assign(defaults, webpackOptions)
+
+    // if svg react loader options are passed, 
+    // add them to a query dictionary and append that
+    if (Object.keys(svgReactLoaderOptions)) {
+        // query is necessary because that's how the API works
+        // see: https://github.com/jhamlet/svg-react-loader#query-params
+        const queryOptions = { query: svgReactLoaderOptions }
+        svgReactLoader = Object.assign(svgReactLoader, queryOptions)
     }
 
     addBeforeRule(config.module.rules, fileLoaderMatcher, svgReactLoader)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-svg-react-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-svg-react-loader",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
I needed the ability to add webpack options to my rewire (so I could include only certain directories), so I forked the repo and added the options. This PR pulls in those changes + documentation in the README.